### PR TITLE
Add ability to save and load a trained model

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Increasing the learning rate and the dropout.
 ```
 python src/main.py --learning-rate 0.01 --dropout 0.9
 ```
+You can save the trained model by adding the `--save-path` parameter.
+```
+python src/main.py --save-path /path/to/model-name
+```
+Then you can load a pretrained model using the `--load-path` parameter; **note that the model will be used as-is, no training will be performed**.
+```
+python src/main.py --load-path /path/to/model-name
+```
 --------------------------------------------------------------------------------
 
 **License**

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,13 @@ def main():
     args = parameter_parser()
     tab_printer(args)
     trainer = SimGNNTrainer(args)
-    trainer.fit()
+    if args.load_path:
+        trainer.load()
+    else:
+        trainer.fit()
     trainer.score()
+    if args.save_path:
+        trainer.save()
 
 if __name__ == "__main__":
     main()

--- a/src/param_parser.py
+++ b/src/param_parser.py
@@ -80,4 +80,14 @@ def parameter_parser():
 
     parser.set_defaults(histogram=False)
 
+    parser.add_argument("--save-path",
+                        type=str,
+                        default=None,
+                        help="Where to save the trained model")
+
+    parser.add_argument("--load-path",
+                        type=str,
+                        default=None,
+                        help="Load a pretrained model")
+
     return parser.parse_args()

--- a/src/simgnn.py
+++ b/src/simgnn.py
@@ -144,7 +144,7 @@ class SimGNNTrainer(object):
             data = process_pair(graph_pair)
             self.global_labels = self.global_labels.union(set(data["labels_1"]))
             self.global_labels = self.global_labels.union(set(data["labels_2"]))
-        self.global_labels = list(self.global_labels)
+        self.global_labels = sorted(self.global_labels)
         self.global_labels = {val:index  for index, val in enumerate(self.global_labels)}
         self.number_of_labels = len(self.global_labels)
 

--- a/src/simgnn.py
+++ b/src/simgnn.py
@@ -264,3 +264,9 @@ class SimGNNTrainer(object):
         model_error = np.mean(self.scores)
         print("\nBaseline error: " +str(round(base_error, 5))+".")
         print("\nModel test error: " +str(round(model_error, 5))+".")
+
+    def save(self):
+        torch.save(self.model.state_dict(), self.args.save_path)
+
+    def load(self):
+        self.model.load_state_dict(torch.load(self.args.load_path))


### PR DESCRIPTION
To achieve repeatable results, it was also necessary to keep the label in fixed order, so that the resulting one-hot encoding vectors are the same across different runs.

Explanation of this feature has been added to the README.
